### PR TITLE
feat: added taiko client service monitor  

### DIFF
--- a/charts/taiko-client/Chart.yaml
+++ b/charts/taiko-client/Chart.yaml
@@ -6,3 +6,4 @@ version: 0.3.1
 maintainers:
   - name: 0xDones
   - name: AntiD2ta
+  - name: gehlotanish

--- a/charts/taiko-client/Chart.yaml
+++ b/charts/taiko-client/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: taiko-client
 description: A Helm chart for Kubernetes
 type: application
-version: 0.3.0
+version: 0.3.1
 maintainers:
   - name: 0xDones
   - name: AntiD2ta

--- a/charts/taiko-client/README.md
+++ b/charts/taiko-client/README.md
@@ -61,6 +61,7 @@ A Helm chart for Kubernetes
 | clientArgs.prover[8] | string | `"--tx.gasLimit={{ (index .Values .Values.global.network).prover.txGasLimit }}"` |  |
 | clientArgs.prover[9] | string | `"--tx.minBaseFee={{ (index .Values .Values.global.network).prover.txMinBaseFee }}"` |  |
 | env | list | `[]` |  |
+| extraPorts | object | `{}` |  |
 | global.l1Endpoints.l1Beacon | string | `"http://ethereum-node-beacon:5052"` |  |
 | global.l1Endpoints.l1Http | string | `"http://ethereum-node-execution:8545"` |  |
 | global.l1Endpoints.l1Ws | string | `"ws://ethereum-node-execution:8546"` |  |
@@ -97,6 +98,17 @@ A Helm chart for Kubernetes
 | mainnet.l1ContractAddresses.taikoToken | string | `"0x10dea67478c5F8C5E2D90e5E9B26dBe60c54d800"` |  |
 | mainnet.l2ContractAddresses.taikoL2 | string | `"0x1670000000000000000000000000000000010001"` |  |
 | nodeSelector | object | `{}` |  |
+| serviceMonitor.annotations | object | `{}` | Additional ServiceMonitor annotations |
+| serviceMonitor.enabled | bool | `false` | If true, a ServiceMonitor CRD is created for a prometheus operator https://github.com/coreos/prometheus-operator |
+| serviceMonitor.interval | string | `"1m"` | ServiceMonitor scrape interval |
+| serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
+| serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor |
+| serviceMonitor.path | string | `"/metrics"` | Path to scrape |
+| serviceMonitor.port | int | `6060` | Port of metrics expose |
+| serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabelings |
+| serviceMonitor.scheme | string | `"http"` | ServiceMonitor scheme |
+| serviceMonitor.scrapeTimeout | string | `"30s"` | ServiceMonitor scrape timeout |
+| serviceMonitor.tlsConfig | object | `{}` | ServiceMonitor TLS configuration |
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` |  |
 | volumes | list | `[]` |  |

--- a/charts/taiko-client/README.md
+++ b/charts/taiko-client/README.md
@@ -1,6 +1,6 @@
 # taiko-client
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -10,6 +10,7 @@ A Helm chart for Kubernetes
 | ---- | ------ | --- |
 | 0xDones |  |  |
 | AntiD2ta |  |  |
+| gehlotanish |  |  |
 
 ## Values
 

--- a/charts/taiko-client/templates/service.yaml
+++ b/charts/taiko-client/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.mode "prover" }}
+{{- if or (eq .Values.global.mode "prover") .Values.serviceMonitor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,7 +7,18 @@ spec:
   selector:
     {{- include "taiko-client.selectorLabels" . | nindent 4 }}
   ports:
+  {{- if eq .Values.global.mode "prover" }}
     - protocol: TCP
       port: 9876
       targetPort: 9876
+  {{- end }}
+  {{- if .Values.serviceMonitor.enabled }}
+    - protocol: TCP
+      port: {{ .Values.serviceMonitor.port }}
+      targetPort: {{ .Values.serviceMonitor.port }}
+      name: metrics
+  {{- end }}
+  {{- if .Values.extraPorts }}
+    {{ toYaml .Values.extraPorts | nindent 4}}
+  {{- end }}
 {{- end }}

--- a/charts/taiko-client/templates/servicemonitor.yaml
+++ b/charts/taiko-client/templates/servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "taiko-client.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "taiko-client.selectorLabels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations:
+  {{ toYaml .Values.serviceMonitor.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+  - interval: {{ .Values.serviceMonitor.interval }}
+    {{- if .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    honorLabels: true
+    port: metrics
+    path: {{ .Values.serviceMonitor.path }}
+    scheme: {{ .Values.serviceMonitor.scheme }}
+    {{- if .Values.serviceMonitor.tlsConfig }}
+    tlsConfig:
+    {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "taiko-client.selectorLabels" . | nindent 8 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/taiko-client/values.yaml
+++ b/charts/taiko-client/values.yaml
@@ -146,3 +146,30 @@ env: []
   #     secretKeyRef:
   #       name: guardian-private-key
   #       key: private-key
+
+extraPorts: {}
+
+serviceMonitor:
+  # -- If true, a ServiceMonitor CRD is created for a prometheus operator
+  # https://github.com/coreos/prometheus-operator
+  enabled: false
+  # -- Port of metrics expose
+  port: 6060
+  # -- Path to scrape
+  path: /metrics
+  # -- Alternative namespace for ServiceMonitor
+  namespace: null
+  # -- Additional ServiceMonitor labels
+  labels: {}
+  # -- Additional ServiceMonitor annotations
+  annotations: {}
+  # -- ServiceMonitor scrape interval
+  interval: 1m
+  # -- ServiceMonitor scheme
+  scheme: http
+  # -- ServiceMonitor TLS configuration
+  tlsConfig: {}
+  # -- ServiceMonitor scrape timeout
+  scrapeTimeout: 30s
+  # -- ServiceMonitor relabelings
+  relabelings: []


### PR DESCRIPTION
This pull request adds the ServiceMonitor configuration to enable pushing metrics to Prometheus.