### PR TITLE
chore(taiko-client): add env support for driver mode

### DIFF
--- a/charts/taiko-client/Chart.yaml
+++ b/charts/taiko-client/Chart.yaml
@@ -2,8 +2,7 @@ apiVersion: v2
 name: taiko-client
 description: A Helm chart for Kubernetes
 type: application
-version: 0.3.5
+version: 0.3.6
 maintainers:
   - name: 0xDones
-  - name: AntiD2ta
   - name: gehlotanish

--- a/charts/taiko-client/README.md
+++ b/charts/taiko-client/README.md
@@ -1,6 +1,6 @@
 # taiko-client
 
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -9,7 +9,6 @@ A Helm chart for Kubernetes
 | Name | Email | Url |
 | ---- | ------ | --- |
 | 0xDones |  |  |
-| AntiD2ta |  |  |
 | gehlotanish |  |  |
 
 ## Values

--- a/charts/taiko-client/templates/deployment.yaml
+++ b/charts/taiko-client/templates/deployment.yaml
@@ -41,6 +41,12 @@ spec:
             protocol: TCP
         {{- end }}
         {{- end }}
+        {{- if eq .Values.global.mode "driver" }}
+        {{- with .Values.env }}
+        env:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
         {{- if eq .Values.global.mode "proposer" }}
         env:
           {{- if .Values.env }}


### PR DESCRIPTION
## Summary

- Add env block for `driver` mode in template
- Aligns `driver` mode with `proposer`/`prover`/`guardian` modes

## Test plan

- [ ] Deploy taiko-client in driver mode with custom env vars
- [ ] Verify env vars are set in pod: `kubectl exec <pod> -- env | grep VAR_NAME`
- [ ] Verify args are substituted correctly